### PR TITLE
Removes line about Linear in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
 ## ✅ Checklist
 
 - [ ] This pr title describes the issue in a single sentence
-- [ ] The branch is named using the Linear git branch name (which will automatically link them)


### PR DESCRIPTION
## ✅ Checklist

- [x] This pr title describes the issue in a single sentence
- [ ] The branch is named using the Linear git branch name (which will automatically link them)
